### PR TITLE
Refactor: LGTM

### DIFF
--- a/Mecanum.hpp
+++ b/Mecanum.hpp
@@ -8,7 +8,7 @@ class MecanumWheel {
 
 private:
 
-    double wheel[4];
+    double _wheel[4];
 
 public:
 
@@ -17,17 +17,17 @@ public:
 
     void control(double _targetSpeed, double _targetRotation, double _LRturn)
     {
-        wheel[0] = sin(_targetRotation) / cos(_targetRotation) * _targetSpeed - _targetRotation;
-        wheel[1] = cos(_targetRotation) / sin(_targetRotation) * _targetSpeed + _targetRotation;
-        wheel[2] = cos(_targetRotation) / sin(_targetRotation) * _targetSpeed - _targetRotation;
-        wheel[3] = sin(_targetRotation) / cos(_targetRotation) * _targetSpeed + _targetRotation;
+        _wheel[0] = sin(_targetRotation) / cos(_targetRotation) * _targetSpeed - _targetRotation;
+        _wheel[1] = cos(_targetRotation) / sin(_targetRotation) * _targetSpeed + _targetRotation;
+        _wheel[2] = cos(_targetRotation) / sin(_targetRotation) * _targetSpeed - _targetRotation;
+        _wheel[3] = sin(_targetRotation) / cos(_targetRotation) * _targetSpeed + _targetRotation;
     }
 
     double getSpeed(int unit) {
         if(unit < 0 || unit > 3) {
             return 0.0;
         }
-        return wheel[unit];
+        return _wheel[unit];
     }
 };
 

--- a/Mecanum.hpp
+++ b/Mecanum.hpp
@@ -23,20 +23,11 @@ public:
         wheel[3] = sin(_targetRotation) / cos(_targetRotation) * _targetSpeed + _targetRotation;
     }
 
-    double getSpeed_0(){
-        return wheel[0];
-    }
-
-    double getSpeed_1(){
-        return wheel[1];
-    }
-
-    double getSpeed_2(){
-        return wheel[2];
-    }
-
-    double getSpeed_3(){
-        return wheel[3];
+    double getSpeed(int unit) {
+        if(unit < 0 || unit > 3) {
+            return 0.0;
+        }
+        return wheel[unit];
     }
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -77,10 +77,10 @@ int main() {
         mw.control(targetSpeed, targetRotation, LRturn);
 
         // PID制御
-        pid_0.control(encoder_0.get_rps(), mw.getSpeed_0(), DELTA_T);
-        pid_1.control(encoder_1.get_rps(), mw.getSpeed_1(), DELTA_T);
-        pid_2.control(encoder_2.get_rps(), mw.getSpeed_2(), DELTA_T);
-        pid_3.control(encoder_3.get_rps(), mw.getSpeed_3(), DELTA_T);
+        pid_0.control(encoder_0.get_rps(), mw.getSpeed(0), DELTA_T);
+        pid_1.control(encoder_1.get_rps(), mw.getSpeed(1), DELTA_T);
+        pid_2.control(encoder_2.get_rps(), mw.getSpeed(2), DELTA_T);
+        pid_3.control(encoder_3.get_rps(), mw.getSpeed(3), DELTA_T);
 
         // MD出力
         md_0.drive(pid_0.get_pid());

--- a/main.cpp
+++ b/main.cpp
@@ -28,25 +28,31 @@ MecanumWheel mw;
 */
 
 // PIDゲイン調整 {kp(比例), ki(積分), kd(微分)}
-PID pid_0(1.0, 0.1, 0.05);
-PID pid_1(1.0, 0.1, 0.05);
-PID pid_2(1.0, 0.1, 0.05);
-PID pid_3(1.0, 0.1, 0.05);
+PID pid[4] = {
+    PID(1.0, 0.1, 0.05),
+    PID(1.0, 0.1, 0.05),
+    PID(1.0, 0.1, 0.05),
+    PID(1.0, 0.1, 0.05)
+};
 
 // PID用周期調整 (ここを変えるならmainの最後の行も変える)
 double DELTA_T = 0.01;
 
 // エンコーダーの制御ピン (a, b)
-Encoder encoder_0(A0, D0);
-Encoder encoder_1(A1, D1);
-Encoder encoder_2(A2, D2);
-Encoder encoder_3(A3, D3);
+Encoder encoder[4] = {
+    Encoder(A0, D0),
+    Encoder(A1, D1),
+    Encoder(A2, D2),
+    Encoder(A3, D3)
+};
 
 // MDの制御ピン (pwmピン, dirピン, 逆転モード)
-MD md_0(PA_0, PA_4, 0);
-MD md_1(PA_1, PA_5, 0);
-MD md_2(PA_2, PA_6, 0);
-MD md_3(PA_3, PA_7, 0);
+MD md[4] = {
+    MD(PA_0, PA_4, 0),
+    MD(PA_1, PA_5, 0),
+    MD(PA_2, PA_6, 0),
+    MD(PA_3, PA_7, 0),
+};
 
 int main() {
 
@@ -77,16 +83,16 @@ int main() {
         mw.control(targetSpeed, targetRotation, LRturn);
 
         // PID制御
-        pid_0.control(encoder_0.get_rps(), mw.getSpeed(0), DELTA_T);
-        pid_1.control(encoder_1.get_rps(), mw.getSpeed(1), DELTA_T);
-        pid_2.control(encoder_2.get_rps(), mw.getSpeed(2), DELTA_T);
-        pid_3.control(encoder_3.get_rps(), mw.getSpeed(3), DELTA_T);
+        pid[0].control(encoder[0].get_rps(), mw.getSpeed(0), DELTA_T);
+        pid[1].control(encoder[1].get_rps(), mw.getSpeed(1), DELTA_T);
+        pid[2].control(encoder[2].get_rps(), mw.getSpeed(2), DELTA_T);
+        pid[3].control(encoder[3].get_rps(), mw.getSpeed(3), DELTA_T);
 
         // MD出力
-        md_0.drive(pid_0.get_pid());
-        md_1.drive(pid_1.get_pid());
-        md_2.drive(pid_2.get_pid());
-        md_3.drive(pid_3.get_pid());
+        md[0].drive(pid[0].get_pid());
+        md[1].drive(pid[1].get_pid());
+        md[2].drive(pid[2].get_pid());
+        md[3].drive(pid[3].get_pid());
 
         // 周期調整用 (ここを変えるならDELTA_Tも変える)
         ThisThread::sleep_for(10ms);

--- a/pid.hpp
+++ b/pid.hpp
@@ -29,15 +29,14 @@ void control(
     )
 {
 
-error_behind = error_now;
-error_now = feedback_val – target_val;
+    error_behind = error_now;
+    error_now = feedback_val – target_val;
 
-integral += (error_behind + error_now) / 2.0 * DELTA_T;
+    integral += (error_behind + error_now) / 2.0 * DELTA_T;
 
-p = kp * error_behind;
-i = ki * integral;
-d = kd * (error_now - error_behind) / DELTA_T;
-
+    p = kp * error_behind;
+    i = ki * integral;
+    d = kd * (error_now - error_behind) / DELTA_T;
 }
 
 void reset()


### PR DESCRIPTION
![LGTM](https://image.lgtmoon.dev/217772)

## 改善点
- Mecanum: getSpeed()
getSpeedを複数作るのではなく、配列の要素番号を指定すれば値を取得できるようにすると見やすくなると思います。  

before:
```c++
double getSpeed_0(){}
double getSpeed_1(){}
...
``` 
after:
```c++
double getSpeed(int unit){}

//  usage
double speed_1 = getSpeed(1);
``` 

- Mecanum:wheel
wheel配列はプライベート変数なので、変数名の最初にアンダースコアをつけると良いです。  

before:
```c++
private: wheel[4];
...
``` 
after:
```c++
private: _wheel[4];
``` 


- main:array
MD,Encoder,PIDクラスを配列にしました。可読性が上がるかもしれないです。

before:
```c++
PID pid_0(1.0, 0.1, 0.05);
PID pid_1(1.0, 0.1, 0.05);
PID pid_2(1.0, 0.1, 0.05);
PID pid_3(1.0, 0.1, 0.05);
...
``` 
after:
```c++
PID pid[4] = {
    PID(1.0, 0.1, 0.05),
    PID(1.0, 0.1, 0.05),
    PID(1.0, 0.1, 0.05),
    PID(1.0, 0.1, 0.05)
};
``` 


全体的に良かったのでこのまま頑張ってください!